### PR TITLE
fixed gradle shadowJar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,10 @@ allprojects {
 		sign configurations.archives
 	}
 	
+	shadowJar {
+		zip64 true
+	}
+
 
 	eclipse {
 	    project.natures "org.eclipse.buildship.core.gradleprojectnature"


### PR DESCRIPTION
Tiny little fix for the `shadowJar` task which currently does not work because of too many files